### PR TITLE
Appeler react après la citation

### DIFF
--- a/JVChat_Premium.user.js
+++ b/JVChat_Premium.user.js
@@ -3461,7 +3461,8 @@ function insertAtCursor(input, textToInsert) {
     const value = input.value;
     const start = input.selectionStart;
     const end = input.selectionEnd;
-    input.value = value.slice(0, start) + textToInsert + value.slice(end);
+    const newValue = input.value = value.slice(0, start) + textToInsert + value.slice(end);
+    setTextAreaValue(input, newValue);
     input.selectionStart = input.selectionEnd = start + textToInsert.length;
 }
 


### PR DESCRIPTION
Ouais surement patch à l'arrache. Il faut appeler REACT à chaque fois

J'ai vu que tu avais déjà fait la fonction, je me suis permis de le mettre, car après les citations si tu ouvres risi Bank direct.

Ça pète si t'as pas fait une frappe au clavier.

Par contre, effectivement, il va falloir changer les 250 appels (façon de parler) au textearea, par contre est-ce que tu as pu trouver le FS_ je ne sais pas quoi pour pouvoir poster un message sans le bouton officiel.

Quelqu'un qui bosse sur IRC m'a dit qu'il avait trouvé et toi aussi il me semble avec la fonction :
`function getForumPayload()`

Bref en attendant un patch simple  

Patch tout pourri à la hauteur de mes grandes compétences car en dehors du pointeur **, c'est vraiment le truc de nuke Le texte en tapant à côté après une citation arffff.** 

Après je suis en train de me dire si la citation de base Qui était déjà inclus dans le chat si ça ne marchait pas à cause de REACT on peut revenir sur le système de citation qui était prévu avant et l'appliquer directement avec REACT .*

Je dis bien **si** le problème de citation venait de là 