### PR TITLE
(Erreur invisible impossible à masquer et qui prend de la place) + clean up

### DIFF
--- a/JVChat_Premium.user.js
+++ b/JVChat_Premium.user.js
@@ -207,30 +207,7 @@ function getTopicError(elem) {
     return `Le topic présente une erreur: ${error.getAttribute("alt")}`;
 }
 
-function autoHideTurnstileErrorMessages() {
-    const captchaContainers = document.querySelectorAll('.js-captcha');
-    captchaContainers.forEach(container => {
-        const observer = new MutationObserver((mutationsList) => {
-            for (const mutation of mutationsList) {
-                if (mutation.type === 'childList' || mutation.type === 'characterData' || mutation.type === 'subtree') {
-                    const childDivs = Array.from(container.children).filter(el => el.tagName === 'DIV');
-                    if (childDivs.length >= 2) {
-                        const turnstileWidgetDiv = childDivs[childDivs.length - 1];
-                        if (turnstileWidgetDiv && turnstileWidgetDiv.textContent.includes("[Cloudflare Turnstile]")) {
-                            turnstileWidgetDiv.style.display = 'none';
-                        }
-                    }
-                }
-            }
-        });
 
-        observer.observe(container, {
-            childList: true,
-            subtree: true,
-            characterData: true
-        });
-    });
-}
 
 function parseSondage(elem) {
     let blocSondage = elem.getElementsByClassName("bloc-sondage")[0];
@@ -1817,13 +1794,18 @@ function hideCloudfareInfo() {
     }
     const observer = new MutationObserver(() => {
         let cfInfo = document.querySelector(".js-captcha-logo");
-        if (cfInfo) hideElement(cfInfo.parentElement);
+        if (cfInfo) {
+            const parent = cfInfo.parentElement;
+            hideElement(parent);
+            hideElement(parent.nextElementSibling); // cache le frère <div> suivante
+        }
     });
     observer.observe(document.body, {
         childList: true,
         subtree: true
     });
 }
+
 
 function triggerJVChat() {
     // TamperMonkey / Chrome bug: https://github.com/Tampermonkey/tampermonkey/issues/705#issuecomment-493895776
@@ -1903,7 +1885,6 @@ function triggerJVChat() {
     }
 
     manageTextareaSimpleHeight();
-    autoHideTurnstileErrorMessages();
 
     let event = new CustomEvent('jvchat:activation');
     dispatchEvent(event);


### PR DESCRIPTION
Ouais j'ai pas pu le tester en temps réel ça demande de rester longtemps sur le forum.

https://github.com/Rand0max/jvchat-fork/commit/fbcf2e650c10ee3ec2354c92255f21aa564c1b2b

Ouais même avec cette fonction ça bug j'ai l'erreur 
[Screen](https://github.com/user-attachments/assets/b9eeb395-9757-4650-8a34-da2e9fb73e8c)

Pas visuellement mais elle est là du coup je me demandais si C'était pas plus simple de cibler le frère quand tu cibles l'élément parent comme ça tu évites une redondance dans ton code et tu es sûr qu'en sélectionnant le parent ça va masquer tout ce qui est descendant y compris l'erreur qui va repoper

Tu comprendras très vite avec le code j'ai laissé des annotations mais c'est chiant Regarde le screen et **ça se décuple avec le temps si bien qu'à la fin tout est à gauche**

Là t'en profites pour avoir un truc plus efficace moins de redondance et ça suit la logique de ce que t'avais fait à la base.
 

