### PR TITLE
Utilisation de freshHash pour résoudre les citations cassées

### DIFF
--- a/JVChat_Premium.user.js
+++ b/JVChat_Premium.user.js
@@ -1488,11 +1488,10 @@ function parseDate(string) {
 function buildQuoteEvent(messageId) {
     const message = document.querySelector(`.jvchat-message[jvchat-id='${messageId}']`);
     const quoteButton = message.querySelector('.jvchat-quote');
-    const ajaxHash = document.querySelector('input#ajax_hash_liste_messages').value;
     const author = message.querySelector('.jvchat-author').textContent.trim();
     const date = message.querySelector('.jvchat-date').getAttribute('to-quote');
     quoteButton.addEventListener('click', async () => {
-        const url = `https://www.jeuxvideo.com/forums/ajax_citation.php?id_message=${messageId}&ajax_hash=${ajaxHash}`;
+        const url = `https://www.jeuxvideo.com/forums/ajax_citation.php?id_message=${messageId}&ajax_hash=${freshHash}`;
         const response = await fetch(url);
         const result = await response.json();
         let quoteText = result.txt;


### PR DESCRIPTION
Au bout d'un certain temps passé sur JVChat (30 minutes) les citations sont cassées : les citations imbriquées sont aplaties en une seule citation et les stickers sont retirés. Cela provient du comportement par défaut du script lorsque le hash de la page a expiré et que la requête Ajax pour obtenir le texte de citation renvoie une erreur.

Solution : dans la fonction `buildQuoteEvent` le script reprenait le hash de la page du tchat au lieu d'utiliser le hash contenu dans la variable `freshHash` qui lui est constamment mis à jour à chaque requête de `updateMessages`.