### PR TITLE
simplification de la requête post ou c  et edit

### DIFF
--- a/JVChat_Premium.user.js
+++ b/JVChat_Premium.user.js
@@ -1149,7 +1149,7 @@ async function submitEditedMessage(messageBloc, messageId, newText, formSession,
                 'X-Requested-With': 'XMLHttpRequest',
                 'Accept': 'application/json'
             },
-            body: formData,
+            body: formData
         });
         const data = await response.json();
 

--- a/JVChat_Premium.user.js
+++ b/JVChat_Premium.user.js
@@ -884,7 +884,7 @@ function closeAlert(event) {
 
 
 function getMessageIdFromUrl(messageUrl) {
-    const urlObj = new URL(messageUrl);
+    const urlObj = new URL(messageUrl, location.origin);
     if (!urlObj?.hash?.length) return;
     const match = urlObj.hash.match(/^#post_(?<messageid>[0-9]{10})/);
     return match?.groups?.messageid;
@@ -957,16 +957,16 @@ async function postJvcMessage() {
     formulaire.classList.add("jvchat-disabled-form");
     textarea.setAttribute("disabled", "true");
 
+    const forumPayload = freshPayload || getForumPayload();
+    const formSessionData = forumPayload.formSession;
+    
     let formData = new FormData(freshForm);
 
     formData.set("text", textarea.value);
-    formData.set("topicId", getTopicId());
-    formData.set("forumId", getForumId());
+    formData.set("topicId", forumPayload.topicId);
+    formData.set("forumId", forumPayload.forumId);
     formData.set("group", "1");
     formData.set("messageId", "undefined");
-
-    const forumPayload = freshPayload || getForumPayload();
-    const formSessionData = forumPayload.formSession;
 
     for (const key in formSessionData) {
         if (Object.hasOwnProperty.call(formSessionData, key)) {
@@ -974,21 +974,7 @@ async function postJvcMessage() {
         }
     }
 
-    let fs_custom_input = Array.from(freshForm.elements).find(e => /^fs_[a-f0-9]{40}$/i.test(e.name));
-    if (fs_custom_input && !formData.has(fs_custom_input.name)) {
-        formData.set(fs_custom_input.name, fs_custom_input.value);
-    }
-    if (!formData.has("ajax_hash")) {
-        let ajax_hash = freshForm.querySelector('input[name="ajax_hash"]')?.value || freshHash;
-        formData.set("ajax_hash", ajax_hash);
-    }
-
-    const boundary = "----geckoformboundary" + Math.random().toString(16).slice(2);
-    let body = "";
-    for (let [key, value] of formData.entries()) {
-        body += `--${boundary}\r\nContent-Disposition: form-data; name="${key}"\r\n\r\n${value}\r\n`;
-    }
-    body += `--${boundary}--\r\n`;
+    formData.set("ajax_hash", forumPayload.ajaxToken);
 
     let timeout = turboActivated ? 5000 : 20000;
     postingMessage = true;
@@ -1002,12 +988,11 @@ async function postJvcMessage() {
                     "Accept": "application/json",
                     "Accept-Language": "fr",
                     "x-requested-with": "XMLHttpRequest",
-                    "Content-Type": `multipart/form-data; boundary=${boundary}`,
                     "Pragma": "no-cache",
                     "Cache-Control": "no-cache"
                 },
                 referrer: document.URL,
-                body: body,
+                body: formData,
                 mode: "cors"
             }),
             new Promise((_, reject) => setTimeout(() => reject(new Error("Timeout")), timeout))
@@ -1026,7 +1011,7 @@ async function postJvcMessage() {
 
         let messageId = res?.messageId || res?.id || null;
         if (!messageId && response.url) {
-            messageId = getMessageIdFromUrl(response.url);
+            messageId = getMessageIdFromUrl(response.redirectUrl);
         }
         if (messageId) {
             const detail = { 'detail': { id: messageId, content: textarea.value, username: currentUser.author } };
@@ -1034,7 +1019,7 @@ async function postJvcMessage() {
             dispatchEvent(event);
         }
 
-        setTimeout(tryCatch(forceUpdate), 1000);
+        setTimeout(tryCatch(forceUpdate), 0);
 
         setTextAreaValue(textarea, '');
 
@@ -1134,9 +1119,10 @@ function renderEditInterface(messageBloc, messageId, jvcode, formSession, ajaxHa
 }
 
 async function submitEditedMessage(messageBloc, messageId, newText, formSession, ajaxHash) {
-    const topicId = getTopicId();
-    const forumId = getForumId();
+    const topicId = forumPayload.topicId;
+    const forumId = forumPayload.forumId;
     const originalContentDiv = messageBloc.querySelector(".jvchat-content");
+    const originalMsgDiv = messageBloc.querySelector(".jvchat-content .txt-msg");
     const editionDiv = messageBloc.querySelector(".jvchat-edition");
 
     const formData = new FormData();
@@ -1174,7 +1160,7 @@ async function submitEditedMessage(messageBloc, messageId, newText, formSession,
         }
 
         if (data.html) {
-            originalContentDiv.innerHTML = data.html;
+            originalMsgDiv.innerHTML = data.html;
             fixMessage(originalContentDiv);
             detectMosaic(originalContentDiv);
             improveImages(originalContentDiv);

--- a/JVChat_Premium.user.js
+++ b/JVChat_Premium.user.js
@@ -1010,7 +1010,7 @@ async function postJvcMessage() {
         if (handleApiResponseError(res, 'l\'envoi du message')) return;
 
         let messageId = res?.messageId || res?.id || null;
-        if (!messageId && response.url) {
+        if (!messageId && response.redirectUrl) {
             messageId = getMessageIdFromUrl(response.redirectUrl);
         }
         if (messageId) {
@@ -1149,7 +1149,7 @@ async function submitEditedMessage(messageBloc, messageId, newText, formSession,
                 'X-Requested-With': 'XMLHttpRequest',
                 'Accept': 'application/json'
             },
-            body: formData
+            body: formData,
         });
         const data = await response.json();
 

--- a/JVChat_Premium.user.js
+++ b/JVChat_Premium.user.js
@@ -963,8 +963,8 @@ async function postJvcMessage() {
     let formData = new FormData(freshForm);
 
     formData.set("text", textarea.value);
-    formData.set("topicId", forumPayload.topicId);
-    formData.set("forumId", forumPayload.forumId);
+    formData.set("topicId", freshPayload.topicId);
+    formData.set("forumId", freshPayload.forumId);
     formData.set("group", "1");
     formData.set("messageId", "undefined");
 

--- a/JVChat_Premium.user.js
+++ b/JVChat_Premium.user.js
@@ -1010,8 +1010,8 @@ async function postJvcMessage() {
         if (handleApiResponseError(res, 'l\'envoi du message')) return;
 
         let messageId = res?.messageId || res?.id || null;
-        if (!messageId && response.redirectUrl) {
-            messageId = getMessageIdFromUrl(response.redirectUrl);
+        if (!messageId && res.redirectUrl) {
+            messageId = getMessageIdFromUrl(res.redirectUrl);
         }
         if (messageId) {
             const detail = { 'detail': { id: messageId, content: textarea.value, username: currentUser.author } };


### PR DESCRIPTION
Simplification de la requête post ou c 

Utilisation de form data plutôt que de boundary.

Fresh hash est trouvable dans le payload comme topic et forum id (il a juste un nom différent).
Utilisation de lurl du msg présent dans la réponse réseau en JSON. (Désolé pour les 4 commits habitude de XHR, res est le json parse et reponse la reponse reseau, j'ai corrigé pour levent:postMessage). 
le force update à 1000 ms ne sert à rien dans postjvcmsg : quand le serv repond (en post seulement il a déjà l'url du msg donc c'est déjà pret).

Edition :
Pour l'édition, le texte est directement intégré dans txt msg , pour éviter le temps où y'a pas de mise en forme avant force update.

Bref dégrossissement. et **restauration de la fonction event post message**

 clean up quoi .

J'ai pas tout test c'est issu d'un fork perso, mais dans l'idée ça marche, à la limite 1 ou 2 lignes à fix mais fleme.